### PR TITLE
chore: upgrade cirru_edn 0.7.4, edition 2024; bump to 0.0.2

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,4 +25,4 @@ jobs:
 
       - run: rm -rfv dylibs/* && mkdir dylibs/ && ls target/release/ && cp -v target/release/*.* dylibs/
 
-      - run: cr -1
+      - run: cr

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .compact-inc.cirru
 
 /dylibs/
+
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,27 +3,8 @@
 version = 4
 
 [[package]]
-name = "bincode"
-version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
-dependencies = [
- "bincode_derive",
- "serde",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "calcit_command"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "cirru_edn",
  "cirru_parser",
@@ -31,23 +12,23 @@ dependencies = [
 
 [[package]]
 name = "cirru_edn"
-version = "0.6.13"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f37aff5e74ee2d4df6cbb465f3d4b988b667c7e6e04814484106e2217a5a7a"
+checksum = "b47f4173f6758afa15d0ad76bb9013a17b8a7da89a05e2b2a60cbc6b0c071ee9"
 dependencies = [
- "bincode",
  "cirru_parser",
  "cjk",
  "hex",
+ "serde",
 ]
 
 [[package]]
 name = "cirru_parser"
-version = "0.1.31"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320a8dd7792dfd18c39e2b6d06e894028cf2ce0dfb2fcd4964fb730dc37ea150"
+checksum = "6cd74f684ca880e0f809554c676d1cede0bc688a0b184b62adef58f5e52b22ed"
 dependencies = [
- "bincode",
+ "serde",
 ]
 
 [[package]]
@@ -94,18 +75,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -114,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -134,12 +125,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "virtue"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "widestring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "calcit_command"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["tiye <jiyinyiyong@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "calcit_command"
@@ -13,5 +13,5 @@ crate-type = ["dylib"] # Creates dynamic lib
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_edn = "0.6.13"
-cirru_parser = "0.1.31"
+cirru_edn = "0.7.4"
+cirru_parser = "0.2.4"

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,2 +1,2 @@
 {}
-  :calcit-version |0.9.9
+  :calcit-version |0.12.14

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,18 @@
 use cirru_edn::Edn;
 use std::process::Command;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn abi_version() -> String {
   String::from("0.0.9")
 }
 
+#[unsafe(no_mangle)]
+pub fn edn_version() -> String {
+  cirru_edn::version().to_owned()
+}
 
 /// simple command to run a command, without options
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn run_command(args: Vec<Edn>) -> Result<Edn, String> {
   let mut xs = vec![];
   for arg in args.iter() {


### PR DESCRIPTION
- upgrade cirru_edn 0.7.4, cirru_parser 0.2.4\n- switch to edition 2024\n- add edn_version() export\n- update calcit-version to 0.12.14